### PR TITLE
Add encodeURIComponent (issue #5)

### DIFF
--- a/hstspreload.appspot.com/index.html
+++ b/hstspreload.appspot.com/index.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=0.5">
   <title>HSTS Preload Submission</title>
   <link rel="stylesheet" href="style.css">
@@ -16,13 +18,23 @@
     </div>
   </div>
 
-  <div id="entry">
-    <h2><label for="textinput">Enter a domain to include in the HSTS preload list:</label></h2>
-    <input id="textinput" onkeypress="keypress(event)" type="text" placeholder="example.com" autofocus></input>
+  <form action="./" method="post" accept-charset="UTF-8" id="entry">
 
-    <p id="error"></p>
-    <div id="msg"></div>
-  </div>
+    <h2><label for="textinput">Enter a domain to include in the HSTS preload list:</label></h2>
+
+    <div id="output"></div>
+
+    <input id="textinput" type="text" placeholder="example.com" autofocus="autofocus" />
+
+    <div id="confirmwrapper">
+        <span><input type="checkbox" id="confirm" name="confirm" value="true" required="required" /> </span><label for="confirm">I understand that preloading a domain through this form will require every subdomain of this site to serve a valid certificate (for that subdomain) in order to remain accessible in Chrome.</label>
+    </div>
+
+    <div id="submit">
+		<input type="submit" value="Submit" />
+	</div>
+
+  </form>
 
   <div class="inner-content">
 

--- a/hstspreload.appspot.com/index.js
+++ b/hstspreload.appspot.com/index.js
@@ -176,18 +176,28 @@ function clearOutput() {
 }
 
 function showError(msg) {
-  var p = document.createElement('p');
-  p.textContent = "Sorry! " + msg;
-  p.setAttribute('class', 'error');
-  document.getElementById("output").appendChild(p);
-  document.getElementById("textinput").disabled = false;
+  showMessage("Sorry! " + msg, true);
 }
 
-function showMessage(msg) {
-  var p = document.createElement('p');
+function showMessage(msg, error) {
+
+  var p = document.createElement('p'),
+      output = document.getElementById("output"),
+      input = document.getElementById("textinput");
+
   p.textContent = msg;
-  document.getElementById("output").appendChild(p);
-  document.getElementById("textinput").disabled = false;
+  if (error) {
+    p.setAttribute('class', 'error');
+  }
+
+  output.appendChild(p);
+  output.setAttribute('tabindex', -1);
+  output.setAttribute('role', 'alert');
+  output.style.outline = 'none';
+  output.focus();
+
+  input.disabled = false;
+
 }
 
 function init() {

--- a/hstspreload.appspot.com/index.js
+++ b/hstspreload.appspot.com/index.js
@@ -1,10 +1,11 @@
+
 var requestedDomain = "";
 
-function keypress(e) {
-  var code = (e.keyCode ? e.keyCode : e.which);
-  if (code != 13) {
-    return;
-  }
+function entrySubmit(e) {
+
+  e = e || window.event;
+  if (e.preventDefault) e.preventDefault();
+  e.returnValue = false;
 
   var textInput = document.getElementById("textinput");
   textInput.disabled = true;
@@ -31,9 +32,11 @@ function keypress(e) {
   xhr.timeout = 10000;
   requestedDomain = domain;
   xhr.send(null);
+
 }
 
 function handleReply(progress) {
+
   var xhr = progress.target;
 
   if (xhr.readyState != 4) {
@@ -71,7 +74,7 @@ function handleReply(progress) {
     var button = document.createElement('input');
     button.type = "submit";
     button.value = "Clear";
-    document.getElementById("msg").appendChild(button);
+    document.getElementById("output").appendChild(button);
     button.onclick = function(e) {
       document.getElementById("textinput").disabled = true;
       clearOutput();
@@ -133,7 +136,7 @@ function handleReply(progress) {
 
     var p = document.createElement('p');
     p.innerHTML = "Next, <a href=\"https://www.ssllabs.com/ssltest/analyze.html?d=" + encodeURIComponent(requestedDomain) + "\">check your HTTPS configuration</a> and fix any issues!";
-    document.getElementById("msg").appendChild(p);
+    document.getElementById("output").appendChild(p);
 
     document.getElementById("textinput").value = "";
     return;
@@ -166,21 +169,36 @@ function handleClearReply(progress) {
 }
 
 function clearOutput() {
-  var msgDiv = document.getElementById("msg");
-  while (msgDiv.hasChildNodes()) {
-    msgDiv.removeChild(msgDiv.lastChild);
+  var outputDiv = document.getElementById("output");
+  while (outputDiv.hasChildNodes()) {
+    outputDiv.removeChild(outputDiv.lastChild);
   }
-  document.getElementById("error").textContent = "";
 }
 
 function showError(msg) {
-  document.getElementById("error").textContent = "Sorry! " + msg;
+  var p = document.createElement('p');
+  p.textContent = "Sorry! " + msg;
+  p.setAttribute('class', 'error');
+  document.getElementById("output").appendChild(p);
   document.getElementById("textinput").disabled = false;
 }
 
 function showMessage(msg) {
   var p = document.createElement('p');
   p.textContent = msg;
-  document.getElementById("msg").appendChild(p);
+  document.getElementById("output").appendChild(p);
   document.getElementById("textinput").disabled = false;
+}
+
+function init() {
+  var entryForm = document.getElementById('entry');
+  if (entryForm) {
+    entryForm.addEventListener('submit', entrySubmit);
+  }
+}
+
+if (document.readyState !== 'loading') {
+  window.setTimeout(init); // Handle asynchronously
+} else {
+  document.addEventListener('DOMContentLoaded', init);
 }

--- a/hstspreload.appspot.com/index.js
+++ b/hstspreload.appspot.com/index.js
@@ -132,7 +132,7 @@ function handleReply(progress) {
     showMessage("Thank you! That domain has been queued for review. Review can take several weeks. You can check the status by entering the same domain again in the future.");
 
     var p = document.createElement('p');
-    p.innerHTML = "Next, <a href=\"https://www.ssllabs.com/ssltest/analyze.html?d=" + requestedDomain + "\">check your HTTPS configuration</a> and fix any issues!";
+    p.innerHTML = "Next, <a href=\"https://www.ssllabs.com/ssltest/analyze.html?d=" + encodeURIComponent(requestedDomain) + "\">check your HTTPS configuration</a> and fix any issues!";
     document.getElementById("msg").appendChild(p);
 
     document.getElementById("textinput").value = "";

--- a/hstspreload.appspot.com/index.js
+++ b/hstspreload.appspot.com/index.js
@@ -24,7 +24,7 @@ function keypress(e) {
   }
 
   var xhr = new XMLHttpRequest();
-  xhr.open("POST", "/submit/" + domain, true);
+  xhr.open("POST", "/submit/" + encodeURIComponent(domain), true);
   xhr.onreadystatechange = handleReply;
   xhr.onerror = handleError;
   xhr.onTimeout = handleTimeout;
@@ -77,7 +77,7 @@ function handleReply(progress) {
       clearOutput();
 
       var xhr = new XMLHttpRequest();
-      xhr.open("POST", "/clear/" + requestedDomain, true);
+      xhr.open("POST", "/clear/" + encodeURIComponent(requestedDomain), true);
       xhr.onreadystatechange = handleClearReply;
       xhr.onerror = handleError;
       xhr.onTimeout = handleTimeout;

--- a/hstspreload.appspot.com/style.css
+++ b/hstspreload.appspot.com/style.css
@@ -18,7 +18,7 @@ body {
 
 .ribbon {
   width: 100%;
-  height: 40vh;
+  height: 20em; /* 40vh causes the ribbon to move when an error message appears */
   background-color: #3F51B5;
 }
 
@@ -27,7 +27,8 @@ body {
   font-size: 14px;
   background-color: #ffffff;
   color: #424242;
-  margin: calc(-35vh + 16px) auto 80px;
+  /*margin: calc(-35vh + 16px) auto 80px; - now the height isn't 40vh, we don't need calc() */
+  margin: -20em auto 0;
   max-width: 939px;
   width: calc(80% - 138px);
   box-shadow:0 4px 5px 0 rgba(0,0,0,.14),0 1px 10px 0 rgba(0,0,0,.12),0 2px 4px -1px rgba(0,0,0,.2);
@@ -94,15 +95,29 @@ p {
   text-align: center;
 }
 
-#entry input {
+#entry #textinput {
   font-family: sans-serif;
-  margin: auto;
+  margin: 1em auto;
   font-size: 1.5em;
   display: block;
-  margin-bottom: 1em;
   width: 100%;
   max-width: 20em;
   text-align: center;
+}
+
+#entry #confirmwrapper {
+  padding: 0 2em 0 3.8em;
+  margin-bottom: 1em;
+}
+
+#entry #confirmwrapper span {
+  width: 1.8em;
+  margin: 0 0 0 -1.8em;
+  display: inline-block;
+}
+
+#entry #submit {
+  padding: 0 2em;
 }
 
 #entry p {
@@ -112,7 +127,7 @@ p {
   text-align: center;
 }
 
-#error {
+#entry p.error {
   color: red;
 }
 


### PR DESCRIPTION
I did try creating these as two separate pull requests, but it looks like GitHub only likes to work from Master.

---

The two XMLHttpRequest POST requests should be checked though, as I'm not sure how the backend server will handle these (although, as it only accepts A-Z, 0-9, Hyphen, and Dot characters, it should be fine).

	domain = strings.ToLower(domain)
	for _, r := range domain {
		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
			continue
		}
		return replyJSON{err: errors.New("domain contains invalid characters")}
	}

https://github.com/chromium/hstspreload/blob/master/hstspreload.appspot.com/hstspreload.go#L277

---

For reference: "encodeURIComponent escapes all characters except the following: alphabetic, decimal digits, - _ . ! ~ * ' ( )"

https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent