### PR TITLE
Add support for Expect-Staple report URIs

### DIFF
--- a/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
+++ b/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
@@ -449,7 +449,7 @@ func checkCertsInPinsets(pinsets []pinset, pins []pin) error {
 
 func checkNoopEntries(entries []hsts) error {
 	for _, e := range entries {
-		if len(e.Mode) == 0 && len(e.Pins) == 0 && !e.ExpectCT {
+		if len(e.Mode) == 0 && len(e.Pins) == 0 && !e.ExpectCT && !e.ExpectStaple {
 			switch e.Name {
 			// This entry is deliberately used as an exclusion.
 			case "learn.doubleclick.net":
@@ -539,12 +539,13 @@ func writeExpectReportURIIds(out *bufio.Writer, entries []hsts) (map[string]int,
 	}
 	out.WriteString("};\n")
 
+	i = 0
 	out.WriteString("static const char* const kExpectStapleReportURIs[] = {\n")
 	for _, e := range entries {
 		if e.ExpectStaple {
 			if _, seen := staple[e.ExpectStapleReportURI]; !seen {
 				out.WriteString("    \"" + e.ExpectStapleReportURI + "\",\n")
-				ct[e.ExpectCTReportURI] = i
+				staple[e.ExpectStapleReportURI] = i
 				i = i + 1
 			}
 		}
@@ -750,11 +751,12 @@ static const uint8_t kPreloadedHSTSData[] = {
 
 	hstsLiteralWriter = cLiteralWriter{out: out}
 	hstsBitWriter = trieWriter{
-		w:                    &hstsLiteralWriter,
-		pinsets:              pinsets,
-		domainIDs:            domainIDs,
-		expectCTReportURIIds: expectCTReportURIIds,
-		huffman:              huffmanMap,
+		w:                        &hstsLiteralWriter,
+		pinsets:                  pinsets,
+		domainIDs:                domainIDs,
+		expectCTReportURIIds:     expectCTReportURIIds,
+		expectStapleReportURIIds: expectStapleReportURIIds,
+		huffman:                  huffmanMap,
 	}
 
 	rootPosition, err := writeEntries(&hstsBitWriter, hsts.Entries)

--- a/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
+++ b/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
@@ -62,15 +62,16 @@ type pinset struct {
 }
 
 type hsts struct {
-	Name                  string `json:"name"`
-	Subdomains            bool   `json:"include_subdomains"`
-	SubdomainsForPinning  bool   `json:"include_subdomains_for_pinning"`
-	Mode                  string `json:"mode"`
-	Pins                  string `json:"pins"`
-	ExpectCT              bool   `json:"expect_ct"`
-	ExpectCTReportURI     string `json:"expect_ct_report_uri"`
-	ExpectStaple          bool   `json:"expect_staple"`
-	ExpectStapleReportURI string `json:"expect_staple_report_uri"`
+	Name                   string `json:"name"`
+	Subdomains             bool   `json:"include_subdomains"`
+	SubdomainsForPinning   bool   `json:"include_subdomains_for_pinning"`
+	Mode                   string `json:"mode"`
+	Pins                   string `json:"pins"`
+	ExpectCT               bool   `json:"expect_ct"`
+	ExpectCTReportURI      string `json:"expect_ct_report_uri"`
+	ExpectStaple           bool   `json:"expect_staple"`
+	ExpectStapleSubdomains bool   `json:"include_subdomains_for_expect_staple"`
+	ExpectStapleReportURI  string `json:"expect_staple_report_uri"`
 }
 
 func main() {
@@ -1177,6 +1178,11 @@ func writeDispatchTables(w *trieWriter, ents reversedEntries, depth int) (positi
 			}
 			if hsts.ExpectStaple {
 				buf.WriteBit(1)
+				if hsts.ExpectStapleSubdomains {
+					buf.WriteBit(1)
+				} else {
+					buf.WriteBit(0)
+				}
 				expectStapleReportURIId, ok := w.expectStapleReportURIIds[hsts.ExpectStapleReportURI]
 				if !ok {
 					panic("missing expect-staple report URI ID for " + hsts.Name)


### PR DESCRIPTION
This allows expect-staple report URIs to be added to the Huffman table
generated by transport_security_state_static_generator.

I don't really expect this to be merge ready, but mostly wanted to check that I wasn't doing anything ridiculously wrong. For reference, Expect-Staple is described at https://docs.google.com/document/d/1aISglJIIwglcOAhqNfK-2vtQl-_dWAapc-VLDh-9-BE/edit#heading=h.rkpittae54q