### PR TITLE
Sort the pinsets and add logging for debugging.

### DIFF
--- a/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
+++ b/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
@@ -61,6 +61,12 @@ type pinset struct {
 	ReportURI string   `json:"report_uri"`
 }
 
+type PinsetNameSorter []pinset
+
+func (a PinsetNameSorter) Len() int           { return len(a) }
+func (a PinsetNameSorter) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a PinsetNameSorter) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
 type hsts struct {
 	Name                   string `json:"name"`
 	Subdomains             bool   `json:"include_subdomains"`
@@ -659,6 +665,7 @@ static const char kNoReportURI[] = "";
 	pinsets := make(map[string]pinsetData)
 	pinsetNum := 0
 
+	sort.Stable(PinsetNameSorter(hsts.Pinsets))
 	for _, pinset := range hsts.Pinsets {
 		name := uppercaseFirstLetter(pinset.Name)
 		acceptableListName := fmt.Sprintf("k%sAcceptableCerts", name)

--- a/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
+++ b/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
@@ -44,12 +44,26 @@ type pin struct {
 	spkiHashFunc string // i.e. "sha256"
 }
 
+type pins []pin
+
+func (a pins) Len() int {
+	return len(a)
+}
+
+func (a pins) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a pins) Less(i, j int) bool {
+	return a[i].name < a[j].name
+}
+
 // preloaded represents the information contained in the
 // transport_security_state_static.json file. This structure and the two
 // following are used by the "json" package to parse the file. See the comments
 // in transport_security_state_static.json for details.
 type preloaded struct {
-	Pinsets   []pinset `json:"pinsets"`
+	Pinsets   pinsets  `json:"pinsets"`
 	Entries   []hsts   `json:"entries"`
 	DomainIDs []string `json:"domain_ids"`
 }
@@ -61,11 +75,19 @@ type pinset struct {
 	ReportURI string   `json:"report_uri"`
 }
 
-type PinsetNameSorter []pinset
+type pinsets []pinset
 
-func (a PinsetNameSorter) Len() int           { return len(a) }
-func (a PinsetNameSorter) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a PinsetNameSorter) Less(i, j int) bool { return a[i].Name < a[j].Name }
+func (a pinsets) Len() int {
+	return len(a)
+}
+
+func (a pinsets) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a pinsets) Less(i, j int) bool {
+	return a[i].Name < a[j].Name
+}
 
 type hsts struct {
 	Name                   string `json:"name"`
@@ -204,7 +226,7 @@ func removeComments(r io.Reader) ([]byte, error) {
 // parseCertsFile parses |inFile|, in the format of
 // transport_security_state_static.pins. See the comments at the top of that
 // file for details of the format.
-func parseCertsFile(inFile io.Reader) ([]pin, error) {
+func parseCertsFile(inFile io.Reader) (pins, error) {
 	const (
 		PRENAME = iota
 		POSTNAME
@@ -219,7 +241,7 @@ func parseCertsFile(inFile io.Reader) ([]pin, error) {
 	var pemPublicKey []byte
 	state := PRENAME
 	var name string
-	var pins []pin
+	var pins pins
 
 	for {
 		lineNo++
@@ -394,7 +416,7 @@ func isImportantWordInCertificateName(w string) bool {
 }
 
 // checkDuplicatePins returns an error if any pins have the same name or the same hash.
-func checkDuplicatePins(pins []pin) error {
+func checkDuplicatePins(pins pins) error {
 	seenNames := make(map[string]bool)
 	seenHashes := make(map[string]string)
 
@@ -418,7 +440,7 @@ func checkDuplicatePins(pins []pin) error {
 //   a) unknown pins are mentioned in |pinsets|
 //   b) unused pins are given in |pins|
 //   c) a pinset name is used twice
-func checkCertsInPinsets(pinsets []pinset, pins []pin) error {
+func checkCertsInPinsets(pinsets pinsets, pins pins) error {
 	pinNames := make(map[string]bool)
 	for _, pin := range pins {
 		pinNames[pin.name] = true
@@ -562,12 +584,13 @@ func writeExpectReportURIIds(out *bufio.Writer, entries []hsts) (map[string]int,
 	return ct, staple
 }
 
-func writeCertsOutput(out *bufio.Writer, pins []pin) {
+func writeCertsOutput(out *bufio.Writer, pins pins) {
 	out.WriteString(`// These are SubjectPublicKeyInfo hashes for public key pinning. The
 // hashes are SHA256 digests.
 
 `)
 
+	sort.Stable(pins)
 	for _, pin := range pins {
 		fmt.Fprintf(out, "static const char kSPKIHash_%s[] =\n", pin.name)
 		var s1, s2 string
@@ -665,7 +688,7 @@ static const char kNoReportURI[] = "";
 	pinsets := make(map[string]pinsetData)
 	pinsetNum := 0
 
-	sort.Stable(PinsetNameSorter(hsts.Pinsets))
+	sort.Stable(hsts.Pinsets)
 	for _, pinset := range hsts.Pinsets {
 		name := uppercaseFirstLetter(pinset.Name)
 		acceptableListName := fmt.Sprintf("k%sAcceptableCerts", name)

--- a/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
+++ b/cmd/transport_security_state_static_generate/transport_security_state_static_generate.go
@@ -777,6 +777,9 @@ static const uint8_t kPreloadedHSTSData[] = {
 	fmt.Fprintf(out, "static const unsigned kPreloadedHSTSBits = %d;\n\n", bitLength)
 	fmt.Fprintf(out, "static const unsigned kHSTSRootPosition = %d;\n\n", rootPosition)
 
+	fmt.Printf("Bit length %d\n", bitLength)
+	fmt.Printf("Root position %d\n", rootPosition)
+
 	return nil
 }
 


### PR DESCRIPTION
Not intended to be merged, this PR is just easier to link to.

These changes are for debugging and testing. Sorting the pinsets mimics the behaviour of having them in an `std::map`. Having the pinsets in different order would result in different pinset IDs, which results in a different trie output, sorting them solves that and makes testing easier.