### PR TITLE
Elaborating on error message for `redirects.http.www_first`

### DIFF
--- a/redirects.go
+++ b/redirects.go
@@ -141,7 +141,9 @@ func preloadableHTTPRedirectsURL(initialURL string, domain string) (general, fir
 			IssueCode("redirects.http.www_first"),
 			"HTTP redirects to www first",
 			"`%s` (HTTP) should immediately redirect to `%s` (HTTPS) "+
-				"before adding the www subdomain. Right now, the first redirect is to `%s`.",
+			   "before adding the www subdomain. Right now, the first redirect is to `%s`. " +
+         "The extra redirect is required to ensure that any browser which supports HSTS will " +
+         "record the HSTS entry for the top level domain, not just the subdomain.",
 			initialURL,
 			"https://"+domain,
 			chain[0],

--- a/redirects_test.go
+++ b/redirects_test.go
@@ -246,7 +246,7 @@ var preloadableHTTPRedirectsTests = []preloadableHTTPRedirectsTest{
 				},
 				{
 					Code:    "redirects.http.www_first",
-					Message: "`http://blogger.com` (HTTP) should immediately redirect to `https://blogger.com` (HTTPS) before adding the www subdomain. Right now, the first redirect is to `http://www.blogger.com/`.",
+					Message: "`http://blogger.com` (HTTP) should immediately redirect to `https://blogger.com` (HTTPS) before adding the www subdomain. Right now, the first redirect is to `http://www.blogger.com/`. The extra redirect is required to ensure that any browser which supports HSTS will record the HSTS entry for the top level domain, not just the subdomain.",
 				},
 			},
 		},


### PR DESCRIPTION
This addresses issue #77, with the new error message coming from [this discussion](https://github.com/chromium/hstspreload.org/issues/33#issuecomment-220762467).