### PR TITLE
Return preload status of domains included by its ancestor domain

### DIFF
--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -107,9 +107,8 @@ func parentDomain(domain string) (string, bool) {
 	dot := strings.Index(domain, ".")
 	if dot == -1 || dot == len(domain) {
 		return "", false
-	} else {
-		return domain[dot+1:], true
 	}
+	return domain[dot+1:], true
 }
 
 const (

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -21,9 +21,9 @@ const (
 	ForceHTTPS = "force-https"
 )
 
-// HstsPreloadStatus indicate if a domain is preloaded.
+// HstsPreloadStatus indicates if a domain is preloaded.
 //
-// A domain can be preloaded by virtual of itself being on the preload list,
+// A domain can be preloaded by virtue of itself being on the preload list,
 // or by having one of its ancestor domains on the list and having
 // "include_subdomains" set to true on that ancestor domain.
 type HstsPreloadStatus int
@@ -78,9 +78,9 @@ func (p PreloadList) Index() (idx IndexedEntries) {
 	}
 }
 
-// Get returns an entry from the index preloaed list along with a status
+// Get returns an entry from the index preload list along with a status
 // indicating how the entry is found. If the domain itself is on the preload
-// list, its entry is return. If one of the the domain's ancestor is on the
+// list, its entry is returned. If one of its ancestor domain is on the
 // list, and "include_subdomains" is set on that ancestor domain, the ancestor
 // entry is return. Failing all that, a zero-value entry is returned.
 func (idx IndexedEntries) Get(domain string) (Entry, HstsPreloadStatus) {

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -24,7 +24,7 @@ const (
 type HstsPreloadStatus int
 
 const (
-	NotFound           HstsPreloadStatus = 1 << iota
+	NotFound           HstsPreloadStatus = iota
 	ExactEntryFound
 	AncestorEntryFound
 )
@@ -79,11 +79,12 @@ func (idx IndexedEntries) Get(domain string) (Entry, HstsPreloadStatus) {
 	if ok {
 		return entry, ExactEntryFound
 	} else {
-		for i := strings.Index(domain, "."); i != -1; domain = domain[i:] {
+		for i := strings.Index(domain, "."); i != -1 && i != len(domain)-1; domain = domain[i+1:] {
 			entry, ok = idx.index[domain]
 			if ok && entry.IncludeSubDomains {
 				return entry, AncestorEntryFound
 			}
+			i = strings.Index(domain, ".")
 		}
 	}
 	return Entry{"", "", false}, NotFound

--- a/chromium/preloadlist/preloadlist_test.go
+++ b/chromium/preloadlist/preloadlist_test.go
@@ -12,7 +12,7 @@ func TestIndexing(t *testing.T) {
 		Entries: []Entry{
 			{
 				Name:              "garron.NET",
-				Mode:              "ForceHTTPS",
+				Mode:              "force-https",
 				IncludeSubDomains: true,
 			},
 			{
@@ -22,7 +22,7 @@ func TestIndexing(t *testing.T) {
 			},
 			{
 				Name:              "bar",
-				Mode:              "ForceHTTPS",
+				Mode:              "force-https",
 				IncludeSubDomains: true,
 			},
 		},
@@ -35,7 +35,7 @@ func TestIndexing(t *testing.T) {
 	}
 
 	_, ok := idx.Get("example")
-	if ok != NotFound {
+	if ok != EntryNotFound {
 		t.Errorf("Entry should not be present.")
 	}
 
@@ -43,7 +43,7 @@ func TestIndexing(t *testing.T) {
 	if ok != ExactEntryFound {
 		t.Errorf("Entry should be present.")
 	}
-	if entry.Mode != "ForceHTTPS" {
+	if entry.Mode != "force-https" {
 		t.Errorf("Map has invalid entry.")
 	}
 
@@ -62,12 +62,15 @@ func TestIndexing(t *testing.T) {
 	if ok == AncestorEntryFound {
 		t.Errorf("Ancestor entry found, but it does not include subdomains.")
 	}
+	if entry.IncludeSubDomains {
+		t.Errorf("Ancestory entry should not include subdomains.")
+	}
 
 	entry, ok = idx.Get("foo.bar")
 	if ok != AncestorEntryFound {
 		t.Errorf("Ancestor entry should be present.")
 	}
-	if entry.Name != "bar" || entry.Mode != "ForceHTTPS" {
+	if entry.Name != "bar" || entry.Mode != "force-https" {
 		t.Errorf("Wrong ancestor entry found.")
 	}
 	if !entry.IncludeSubDomains {

--- a/chromium/preloadlist/preloadlist_test.go
+++ b/chromium/preloadlist/preloadlist_test.go
@@ -70,10 +70,17 @@ func TestIndexing(t *testing.T) {
 	if entry.Name != "bar" || entry.Mode != "ForceHTTPS" {
 		t.Errorf("Wrong ancestor entry found.")
 	}
-	if entry.IncludeSubDomains {
+	if !entry.IncludeSubDomains {
 		t.Errorf("Ancestor entry does not include subdomains.")
 	}
 
+	entry, ok = idx.Get("bar")
+	if ok != ExactEntryFound {
+		t.Errorf("Entry should be present.")
+	}
+	if entry.Name != "bar" || entry.Mode != "ForceHTTPS" || !entry.IncludeSubDomains {
+		t.Errorf("Wrong entry entry found.")
+	}
 }
 
 func TestNewFromLatest(t *testing.T) {

--- a/chromium/preloadlist/preloadlist_test.go
+++ b/chromium/preloadlist/preloadlist_test.go
@@ -20,27 +20,60 @@ func TestIndexing(t *testing.T) {
 				Mode:              "",
 				IncludeSubDomains: false,
 			},
+			{
+				Name:              "bar",
+				Mode:              "ForceHTTPS",
+				IncludeSubDomains: true,
+			},
 		},
 	}
 
 	idx := list.Index()
 
-	if len(idx.index) != 2 {
+	if len(idx.index) != 3 {
 		t.Errorf("Map has the wrong number of entries.")
 	}
 
 	_, ok := idx.Get("example")
-	if ok {
+	if ok != NotFound {
 		t.Errorf("Entry should not be present.")
 	}
 
 	entry, ok := idx.Get("GARRON.net")
-	if !ok {
+	if ok != ExactEntryFound {
 		t.Errorf("Entry should be present.")
 	}
 	if entry.Mode != "ForceHTTPS" {
 		t.Errorf("Map has invalid entry.")
 	}
+
+	entry, ok = idx.Get("www.garron.net")
+	if ok != AncestorEntryFound {
+		t.Errorf("Ancestor entry should be present.")
+	}
+	if entry.Name != "garron.NET" {
+		t.Errorf("Wrong ancestor entry found.")
+	}
+	if !entry.IncludeSubDomains {
+		t.Errorf("Ancestor entry does not include subdomains.")
+	}
+
+	entry, ok = idx.Get("test.example.com")
+	if ok == AncestorEntryFound {
+		t.Errorf("Ancestor entry should not be present.")
+	}
+
+	entry, ok = idx.Get("foo.bar")
+	if ok != AncestorEntryFound {
+		t.Errorf("Ancestor entry should be present.")
+	}
+	if entry.Name != "bar" || entry.Mode != "ForceHTTPS" {
+		t.Errorf("Wrong ancestor entry found.")
+	}
+	if entry.IncludeSubDomains {
+		t.Errorf("Ancestor entry does not include subdomains.")
+	}
+
 }
 
 func TestNewFromLatest(t *testing.T) {

--- a/chromium/preloadlist/preloadlist_test.go
+++ b/chromium/preloadlist/preloadlist_test.go
@@ -81,7 +81,7 @@ func TestIndexing(t *testing.T) {
 	if ok != ExactEntryFound {
 		t.Errorf("Entry should be present.")
 	}
-	if entry.Name != "bar" || entry.Mode != "ForceHTTPS" || !entry.IncludeSubDomains {
+	if entry.Name != "bar" || entry.Mode != "force-https" || !entry.IncludeSubDomains {
 		t.Errorf("Wrong entry found.")
 	}
 }

--- a/chromium/preloadlist/preloadlist_test.go
+++ b/chromium/preloadlist/preloadlist_test.go
@@ -60,7 +60,7 @@ func TestIndexing(t *testing.T) {
 
 	entry, ok = idx.Get("test.example.com")
 	if ok == AncestorEntryFound {
-		t.Errorf("Ancestor found, but it does not include subdomains.")
+		t.Errorf("Ancestor entry found, but it does not include subdomains.")
 	}
 
 	entry, ok = idx.Get("foo.bar")
@@ -79,7 +79,7 @@ func TestIndexing(t *testing.T) {
 		t.Errorf("Entry should be present.")
 	}
 	if entry.Name != "bar" || entry.Mode != "ForceHTTPS" || !entry.IncludeSubDomains {
-		t.Errorf("Wrong entry entry found.")
+		t.Errorf("Wrong entry found.")
 	}
 }
 

--- a/chromium/preloadlist/preloadlist_test.go
+++ b/chromium/preloadlist/preloadlist_test.go
@@ -60,7 +60,7 @@ func TestIndexing(t *testing.T) {
 
 	entry, ok = idx.Get("test.example.com")
 	if ok == AncestorEntryFound {
-		t.Errorf("Ancestor entry should not be present.")
+		t.Errorf("Ancestor found, but it does not include subdomains.")
 	}
 
 	entry, ok = idx.Get("foo.bar")

--- a/cmd/hstspreload/main.go
+++ b/cmd/hstspreload/main.go
@@ -117,9 +117,9 @@ includeSubDomains: %s%t%s
 				bold, state.Mode, resetFormat,
 				bold, state.IncludeSubDomains, resetFormat)
 		} else if status == preloadlist.AncestorEntryFound {
-			fmt.Printf(`%s%s%s is preloaded by virtue of its parent domain:
+			fmt.Printf(`%s%s%s is preloaded by virtue of its ancestor domain:
 
-           parent: %s%s%s
+         ancestor: %s%s%s
              mode: %s%s%s
 includeSubDomains: %s%t%s
 

--- a/cmd/hstspreload/main.go
+++ b/cmd/hstspreload/main.go
@@ -106,20 +106,15 @@ func main() {
 		idx := l.Index()
 		domain := args[1]
 		state, status := idx.Get(domain)
-		if status == preloadlist.ExactEntryFound {
-			fmt.Printf(`%s%s%s is preloaded:
-
-             mode: %s%s%s
-includeSubDomains: %s%t%s
+		if status == preloadlist.EntryNotFound {
+			fmt.Printf(`%s%s%s is not preloaded.
 
 `,
-				underline, domain, resetFormat,
-				bold, state.Mode, resetFormat,
-				bold, state.IncludeSubDomains, resetFormat)
-		} else if status == preloadlist.AncestorEntryFound {
-			fmt.Printf(`%s%s%s is preloaded by virtue of its ancestor domain:
+				underline, domain, resetFormat)
+		} else {
+			fmt.Printf(`%s%s%s is preloaded:
 
-         ancestor: %s%s%s
+           domain: %s%s%s
              mode: %s%s%s
 includeSubDomains: %s%t%s
 
@@ -128,11 +123,6 @@ includeSubDomains: %s%t%s
 				bold, state.Name, resetFormat,
 				bold, state.Mode, resetFormat,
 				bold, state.IncludeSubDomains, resetFormat)
-		} else {
-			fmt.Printf(`%s%s%s is not preloaded.
-
-`,
-				underline, domain, resetFormat)
 		}
 		os.Exit(0)
 

--- a/cmd/hstspreload/main.go
+++ b/cmd/hstspreload/main.go
@@ -105,8 +105,8 @@ func main() {
 		}
 		idx := l.Index()
 		domain := args[1]
-		state, ok := idx.Get(domain)
-		if ok {
+		state, status := idx.Get(domain)
+		if status == preloadlist.ExactEntryFound {
 			fmt.Printf(`%s%s%s is preloaded:
 
              mode: %s%s%s
@@ -114,6 +114,18 @@ includeSubDomains: %s%t%s
 
 `,
 				underline, domain, resetFormat,
+				bold, state.Mode, resetFormat,
+				bold, state.IncludeSubDomains, resetFormat)
+		} else if status == preloadlist.AncestorEntryFound {
+			fmt.Printf(`%s%s%s is preloaded by virtue of its parent domain:
+
+           parent: %s%s%s
+             mode: %s%s%s
+includeSubDomains: %s%t%s
+
+`,
+				underline, domain, resetFormat,
+				bold, state.Name, resetFormat,
 				bold, state.Mode, resetFormat,
 				bold, state.IncludeSubDomains, resetFormat)
 		} else {
@@ -227,9 +239,9 @@ func probablyHeader(str string) bool {
 
 func probablyURL(str string) bool {
 	return strings.HasPrefix(str, "http://") ||
-		strings.HasPrefix(str, "https://") ||
-		strings.Contains(str, ":") ||
-		strings.Contains(str, "/")
+			strings.HasPrefix(str, "https://") ||
+			strings.Contains(str, ":") ||
+			strings.Contains(str, "/")
 }
 
 func probablyDomain(str string) bool {

--- a/cmd/hstspreload/main.go
+++ b/cmd/hstspreload/main.go
@@ -239,9 +239,9 @@ func probablyHeader(str string) bool {
 
 func probablyURL(str string) bool {
 	return strings.HasPrefix(str, "http://") ||
-			strings.HasPrefix(str, "https://") ||
-			strings.Contains(str, ":") ||
-			strings.Contains(str, "/")
+		strings.HasPrefix(str, "https://") ||
+		strings.Contains(str, ":") ||
+		strings.Contains(str, "/")
 }
 
 func probablyDomain(str string) bool {


### PR DESCRIPTION
A new Enum `HstsPreloadStatus` is returned by `IndexedEntries.Get` that takes into account if a domain is preloaded because one of its ancestor domains is on the preload list and "include_subdomains" is set to true on that ancestor domain.

This follows suggestions given in #85.