### PR TITLE
clarify ""Max-age > 10 years" warning

### DIFF
--- a/header.go
+++ b/header.go
@@ -242,7 +242,7 @@ func preloadableHeaderMaxAge(hstsHeader HSTSHeader) Issues {
 		issues = issues.addWarningf(
 			"header.preloadable.max_age.over_10_years",
 			"Max-age > 10 years",
-			"FYI: The max-age (%d seconds) is longer than 10 years, which is an unusually long value.",
+			"FYI: The max-age (%d seconds) is longer than 10 years, which is an unusually long value, and may be disregarded by some browsers.",
 			hstsHeader.MaxAge.Seconds,
 		)
 


### PR DESCRIPTION
The warning for a max-age > 10 years does not currently explain why that may be an issue. Explanatory text added.