### PR TITLE
Set custom user agent string for hstspreload

### DIFF
--- a/redirects.go
+++ b/redirects.go
@@ -2,7 +2,6 @@ package hstspreload
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -191,7 +190,6 @@ func preloadableRedirects(initialURL string) (chain []*url.URL, issues Issues) {
 		return nil, issues
 	}
 
-	fmt.Printf("redirects.go setting custom User-Agent: hsts-preload-bot")
 	req.Header.Set("User-Agent", "hsts-preload-bot")
 	_, err = client.Do(req)
 

--- a/redirects.go
+++ b/redirects.go
@@ -2,6 +2,7 @@ package hstspreload
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -185,8 +186,15 @@ func preloadableRedirects(initialURL string) (chain []*url.URL, issues Issues) {
 		},
 		Timeout: dialTimeout,
 	}
+	req, err := http.NewRequest("GET", initialURL, nil)
+	if err != nil {
+		return nil, issues
+	}
 
-	_, err := client.Get(initialURL)
+	fmt.Printf("redirects.go setting custom User-Agent: hsts-preload-bot")
+	req.Header.Set("User-Agent", "hsts-preload-bot")
+	_, err = client.Do(req)
+
 	if err != nil {
 		if strings.HasSuffix(err.Error(), tooManyRedirects.Error()) {
 			issues = issues.addErrorf(

--- a/redirects.go
+++ b/redirects.go
@@ -190,7 +190,7 @@ func preloadableRedirects(initialURL string) (chain []*url.URL, issues Issues) {
 		return nil, issues
 	}
 
-	req.Header.Set("User-Agent", "hsts-preload-bot")
+	req.Header.Set("User-Agent", "hstspreload-bot")
 	_, err = client.Do(req)
 
 	if err != nil {

--- a/response.go
+++ b/response.go
@@ -89,7 +89,7 @@ func getFirstResponseWithTransport(initialURL string, transport *http.Transport)
 		return nil, err
 	}
 
-	req.Header.Set("User-Agent", "hsts-preload-bot")
+	req.Header.Set("User-Agent", "hstspreload-bot")
 	resp, err := client.Do(req)
 
 	if isRedirectPrevented(err) {

--- a/response.go
+++ b/response.go
@@ -2,6 +2,7 @@ package hstspreload
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -84,7 +85,15 @@ func getFirstResponseWithTransport(initialURL string, transport *http.Transport)
 		return ok && urlError.Err == redirectPrevented
 	}
 
-	resp, err := client.Get(initialURL)
+	req, err := http.NewRequest("GET", initialURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("response.go setting custom User-Agent: hsts-preload-bot")
+	req.Header.Set("User-Agent", "hsts-preload-bot")
+	resp, err := client.Do(req)
+
 	if isRedirectPrevented(err) {
 		return resp, nil
 	}

--- a/response.go
+++ b/response.go
@@ -2,7 +2,6 @@ package hstspreload
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -90,7 +89,6 @@ func getFirstResponseWithTransport(initialURL string, transport *http.Transport)
 		return nil, err
 	}
 
-	fmt.Printf("response.go setting custom User-Agent: hsts-preload-bot")
 	req.Header.Set("User-Agent", "hsts-preload-bot")
 	resp, err := client.Do(req)
 


### PR DESCRIPTION
To stop hstspreload from being blocked by CDN and others' user agent filtering (#107), this CL changes the UA string from go's default string to `hsts-preload-bot`. I tested this on a branch for several updates and we have confirmation that some folk were able to allowlist this UA string to avoid the issue with the live queries being blocked.