### PR TITLE
Output a `curl` command for debugging.

### DIFF
--- a/response.go
+++ b/response.go
@@ -2,6 +2,7 @@ package hstspreload
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 )
@@ -12,10 +13,14 @@ func checkSingleHeader(resp *http.Response) (header *string, issues Issues) {
 
 	switch {
 	case len(hstsHeaders) == 0:
+		curlInfo := ""
+		if resp.Request != nil {
+			curlInfo = fmt.Sprintf(" Check that the following terminal command outputs `Strict-Transport-Security`: curl -I \"%v\"", resp.Request.URL)
+		}
 		return nil, issues.addErrorf(
 			"response.no_header",
 			"No HSTS header",
-			"Response error: No HSTS header is present on the response.")
+			"Response error: No HSTS header is present on the response.%s", curlInfo)
 
 	case len(hstsHeaders) > 1:
 		// TODO: Give feedback on the first(last?) HSTS header?


### PR DESCRIPTION
Experimentation for https://github.com/chromium/hstspreload.org/issues/215

I don't think this particular implementation is great, for a few reasons. But it moves the error message closer to specifying exactly what request failed to meet the requirement and how to observe it directly.