### PR TITLE
Added logic so that IP addresses are not treated as preloadable.

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -237,6 +237,14 @@ func checkDomainFormat(domain string) Issues {
 		return issues.addErrorf("domain.format.invalid_characters", "Invalid domain name", "Please provide a domain using valid characters (letters, numbers, dashes, dots).")
 	}
 
+	ip := net.ParseIP(domain)
+	if ip != nil {
+		return issues.addErrorf(
+			IssueCode("domain.format.is_ip_address"),
+			"Invalid domain name",
+			"Please provide a domain, not an IP address")
+	}
+
 	return issues
 }
 

--- a/domain_test.go
+++ b/domain_test.go
@@ -38,6 +38,9 @@ var testCheckDomainFormatTests = []struct {
 	{"example&co.com",
 		Issues{Errors: []Issue{{Code: "domain.format.invalid_characters"}}},
 	},
+	{"1.1.1.1",
+		Issues{Errors: []Issue{{Code: "domain.format.is_ip_address"}}},
+	},
 }
 
 func TestCheckDomainFormat(t *testing.T) {


### PR DESCRIPTION
This closes #105.

Dynamic HSTS isn't supported for IP addresses, which means that IP addresses don't satisfy the dynamic HSTS requirements. Therefore, they shouldn't be preloadable. 