### PR TITLE
Change Policy Field in Entry Struct to be of type PolicyType

### DIFF
--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -48,7 +48,6 @@ type PreloadList struct {
 }
 
 // PolicyType represents the policy under which the domain is a part of the preload list
-// PolicyType values are as defined by https://source.chromium.org/chromium/chromium/src/+/main:net/http/transport_security_state_static.json
 //	- "test": test domains.
 //	- "google": Google-owned sites.
 //	- "custom": entries without includeSubdomains or with HPKP.
@@ -62,6 +61,28 @@ type PreloadList struct {
 //	  the registry for the TLD).
 type PolicyType string 
 
+// PolicyType values are as defined by 
+// https://source.chromium.org/chromium/chromium/src/+/main:net/http/transport_security_state_static.json
+const (
+	// test domains
+	Test PolicyType = "test"
+	// Google-owned sites
+	Google PolicyType = "google"
+	// Entries without includeSubdomains or with HPKP
+	Custom PolicyType = "custom"
+	// Bulk entries preloaded before Chrome 50
+	BulkLegacy PolicyType = "bulk-legacy"
+	// Bulk entries with max-age >= 18 weeks (Chrome 50-63)
+	Bulk18Weeks PolicyType = "bulk-18-weeks"
+	// Bulk entries with max-age >= 1 year (after Chrome 63)
+	Bulk1Year PolicyType = "bulk-1-year"
+	// Public suffixes (e.g. TLDs or other public suffix list entries) preloaded at the owner's request.	
+	PublicSuffix PolicyType = "public-suffix"
+	// domains under a public suffix that have been preloaded at the request of the the public suffix owner
+	// (e.g. the registry for the TLD).
+	PublicSuffixRequested PolicyType = "public-suffix-requested"
+)
+
 // A Entry contains the data from an entry in the Chromium
 // Preload list.
 //
@@ -72,7 +93,7 @@ type PolicyType string
 // - IncludeSubDomains: If Mode == ForceHTTPS, forces HSTS to apply to
 //   all subdomains.
 // 
-// - The policy that was enforced when the the domain was added to the preload list.
+// - Policy: The policy that was enforced when the the domain was added to the preload list.
 //   Will be used to filter lists for automated removal from preload list as domains under
 //   different policies may adhere to different dynamic hsts requirements.
 type Entry struct {

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -48,17 +48,6 @@ type PreloadList struct {
 }
 
 // PolicyType represents the policy under which the domain is a part of the preload list
-//	- "test": test domains.
-//	- "google": Google-owned sites.
-//	- "custom": entries without includeSubdomains or with HPKP.
-//	- "bulk-legacy": bulk entries preloaded before Chrome 50.
-//	- "bulk-18-weeks": bulk entries with max-age >= 18 weeks (Chrome 50-63       ).
-//	- "bulk-1-year": bulk entries with max-age >= 1 year (after Chrome 63)       .
-//	- "public-suffix": public suffixes (e.g. TLDs or other public suffix
-//	  list entries) preloaded at the owner's request.
-//	- "public-suffix-requested": domains under a public suffix that have
-//	  been preloaded at the request of the the public suffix owner (e.g.
-//	  the registry for the TLD).
 type PolicyType string 
 
 // PolicyType values are as defined by 

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -47,6 +47,9 @@ type PreloadList struct {
 	Entries []Entry `json:"entries"`
 }
 
+// PolicyType represents the policy under whcih the domain was added to the preload list
+type PolicyType string 
+
 // A Entry contains the data from an entry in the Chromium
 // Preload list.
 //
@@ -61,10 +64,10 @@ type PreloadList struct {
 //   Will be used to filter lists for automated removal from preload list as domains under
 //   different policies may adhere to different dynamic hsts requirements.
 type Entry struct {
-	Name              string `json:"name"`
-	Mode              string `json:"mode"`
-	IncludeSubDomains bool   `json:"include_subdomains"`
-	Policy            string `json:"policy"`
+	Name              string     `json:"name"`
+	Mode              string     `json:"mode"`
+	IncludeSubDomains bool       `json:"include_subdomains"`
+	Policy            PolicyType `json:"policy"`
 }
 
 // IndexedEntries is case-insensitive index of

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -47,7 +47,7 @@ type PreloadList struct {
 	Entries []Entry `json:"entries"`
 }
 
-// PolicyType represents the policy under whcih the domain was added to the preload list
+// PolicyType represents the policy under which the domain was added to the preload list
 type PolicyType string 
 
 // A Entry contains the data from an entry in the Chromium

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -47,7 +47,19 @@ type PreloadList struct {
 	Entries []Entry `json:"entries"`
 }
 
-// PolicyType represents the policy under which the domain was added to the preload list
+// PolicyType represents the policy under which the domain is a part of the preload list
+// PolicyType values are as defined by https://source.chromium.org/chromium/chromium/src/+/main:net/http/transport_security_state_static.json
+//	- "test": test domains.
+//	- "google": Google-owned sites.
+//	- "custom": entries without includeSubdomains or with HPKP.
+//	- "bulk-legacy": bulk entries preloaded before Chrome 50.
+//	- "bulk-18-weeks": bulk entries with max-age >= 18 weeks (Chrome 50-63       ).
+//	- "bulk-1-year": bulk entries with max-age >= 1 year (after Chrome 63)       .
+//	- "public-suffix": public suffixes (e.g. TLDs or other public suffix
+//	  list entries) preloaded at the owner's request.
+//	- "public-suffix-requested": domains under a public suffix that have
+//	  been preloaded at the request of the the public suffix owner (e.g.
+//	  the registry for the TLD).
 type PolicyType string 
 
 // A Entry contains the data from an entry in the Chromium

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -56,20 +56,20 @@ const (
 	// test domains
 	Test PolicyType = "test"
 	// Google-owned sites
-	Google PolicyType = "google"
+	Google = "google"
 	// Entries without includeSubdomains or with HPKP
-	Custom PolicyType = "custom"
+	Custom = "custom"
 	// Bulk entries preloaded before Chrome 50
-	BulkLegacy PolicyType = "bulk-legacy"
+	BulkLegacy = "bulk-legacy"
 	// Bulk entries with max-age >= 18 weeks (Chrome 50-63)
-	Bulk18Weeks PolicyType = "bulk-18-weeks"
+	Bulk18Weeks = "bulk-18-weeks"
 	// Bulk entries with max-age >= 1 year (after Chrome 63)
-	Bulk1Year PolicyType = "bulk-1-year"
+	Bulk1Year = "bulk-1-year"
 	// Public suffixes (e.g. TLDs or other public suffix list entries) preloaded at the owner's request.	
-	PublicSuffix PolicyType = "public-suffix"
+	PublicSuffix = "public-suffix"
 	// domains under a public suffix that have been preloaded at the request of the the public suffix owner
 	// (e.g. the registry for the TLD).
-	PublicSuffixRequested PolicyType = "public-suffix-requested"
+	PublicSuffixRequested = "public-suffix-requested"
 )
 
 // A Entry contains the data from an entry in the Chromium

--- a/chromium/preloadlist/preloadlist.go
+++ b/chromium/preloadlist/preloadlist.go
@@ -50,7 +50,7 @@ type PreloadList struct {
 // PolicyType represents the policy under which the domain is a part of the preload list
 type PolicyType string 
 
-// PolicyType values are as defined by 
+// Possible PolicyType values are as defined by 
 // https://source.chromium.org/chromium/chromium/src/+/main:net/http/transport_security_state_static.json
 const (
 	// test domains


### PR DESCRIPTION
The reason we changed the Policy Field to be of type PolicyType is to prevent accidental comparison with strings.