### PR TITLE
Skip tests that depend on behavior of external domains

### DIFF
--- a/domain_test.go
+++ b/domain_test.go
@@ -265,6 +265,10 @@ var preloadableDomainTests = []preloadableDomainTest{
 }
 
 func TestPreloadableDomainAndRemovableDomain(t *testing.T) {
+	// Skip this test because it is failing due to relying on behavior of an
+	// external domain: https://github.com/chromium/hstspreload/issues/112.
+	t.SkipNow()
+
 	skipIfShort(t)
 	t.Parallel()
 

--- a/redirects_test.go
+++ b/redirects_test.go
@@ -106,6 +106,10 @@ func TestIndirectInsecureRedirect(t *testing.T) {
 }
 
 func TestExplicitPortFirstRedirect(t *testing.T) {
+	// Skip this test because it is failing due to relying on behavior of an
+	// external domain: https://github.com/chromium/hstspreload/issues/112.
+	t.SkipNow()
+
 	skipIfShort(t)
 	t.Parallel()
 
@@ -127,6 +131,10 @@ func TestExplicitPortFirstRedirect(t *testing.T) {
 }
 
 func TestHTTPUnavailable(t *testing.T) {
+	// Skip this test because it is failing due to relying on behavior of an
+	// external domain: https://github.com/chromium/hstspreload/issues/112.
+	t.SkipNow()
+
 	skipIfShort(t)
 	t.Parallel()
 
@@ -161,6 +169,10 @@ func TestHTTPUnavailable(t *testing.T) {
 }
 
 func TestHSTSOverHTTP(t *testing.T) {
+	// Skip this test because it is failing due to relying on behavior of an
+	// external domain: https://github.com/chromium/hstspreload/issues/112.
+	t.SkipNow()
+
 	skipIfShort(t)
 	t.Parallel()
 
@@ -285,6 +297,10 @@ var preloadableHTTPRedirectsTests = []preloadableHTTPRedirectsTest{
 }
 
 func TestPreloadableHTTPRedirects(t *testing.T) {
+	// Skip this test because it is failing due to relying on behavior of an
+	// external domain: https://github.com/chromium/hstspreload/issues/112.
+	t.SkipNow()
+
 	skipIfShort(t)
 	t.Parallel()
 


### PR DESCRIPTION
These tests should be fixed
(https://github.com/chromium/hstspreload/issues/112); in the meantime
disable them so that `make test` passes.