### PR TITLE
Update versions for linting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '^1.15.0'
+          go-version: '^1.23.0'
       - uses: actions/checkout@v3
       - run: make lint
       - run: make build

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 .PHONY: lint
 lint:
 	go vet ${PROJECT}
-	go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+	go install honnef.co/go/tools/cmd/staticcheck@v0.5.0
 	staticcheck ${PROJECT}
 
 .PHONY: pre-commit


### PR DESCRIPTION
`make lint` is currently failing in CI, probably due to an old version of go or staticcheck.